### PR TITLE
Expose full nodemailer option + do not interfere with template variables

### DIFF
--- a/lib/express-mailer.js
+++ b/lib/express-mailer.js
@@ -59,6 +59,7 @@ exports.extend = function (self, options) {
 
 
 	   if (typeof mailOptions == "function") {
+		 callback = mailOptions;
 	     mailOptions = {};
 	   }
 
@@ -98,6 +99,7 @@ exports.extend = function (self, options) {
       };
 
 	  if (typeof mailOptions == "function") {
+		  callback = mailOptions;
 		  mailOptions = {};
 	  }
 


### PR DESCRIPTION
Hi,

I made a little change in express-mailer.

Nodemailer options should not interfere with the template variables and these options have to be provided as a specific parameter.

I know expose the full Option capability of nodemailer.

I also added possibility to overwrite the from field. One single application should be able to send mails from different expeditors (support@, invoice@, etc...), I kept mailOptions.generateTextFromHTML default to true.

Be careful, I changed version number because this break compatibility with previous function calls.

You can provide backward compatibility by scanning locals.to if you want to do so but it can become confusing, when people add variables like subject to their templates variables.
