### PR TITLE
sending attachments fix

### DIFF
--- a/lib/express-mailer.js
+++ b/lib/express-mailer.js
@@ -65,7 +65,7 @@ exports.extend = function (app, options) {
       // Taken from NodeMailer (libs/nodemailer.js v0.7.1 line 251)
       var acceptedFields = ['from', 'sender', 'to', 'subject', 'replyTo', 'debug',
           'reply_to', 'cc', 'bcc', 'body', 'text', 'html',
-          'envelope', 'inReplyTo', 'references'];
+          'envelope', 'inReplyTo', 'references', 'attachments'];
 
       locals = locals || {};
       for(var i=0;i<acceptedFields.length;i++){


### PR DESCRIPTION
sending mail with attachments did not work due to missing field 'attachment' in acceptedFields array