### PR TITLE
Updated nodemailer dependency + Readme's Jade marking

### DIFF
--- a/lib/express-mailer.js
+++ b/lib/express-mailer.js
@@ -25,7 +25,7 @@ exports.extend = function (app, options) {
   var mailer = {},
       from = options.from, // sender address
       transportMethod = options.transportMethod || 'SMTP',
-      smtpTransport = nodemailer.createTransport(transportMethod, options),
+      smtpTransport = nodemailer.createTransport(options),
       stubTransport,
       sendMail,
       createRender,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-mailer",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "description": "Send Emails from your express application",
   "homepage": "https://github.com/RGBboy/express-mailer",
   "repository": {
@@ -12,6 +12,9 @@
   "contributors": [{
     "name": "Daniel Bretoi",
     "email": "daniel@bretoi.com"
+  },{
+    "name": "Virginie Le Guen Bertheaume",
+    "email": "virginie@virginielgb.com"
   }],
   "repository" : {
     "type" : "git",
@@ -19,20 +22,20 @@
   },
   "main": "index",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=6.0.0"
   },
   "dependencies": {
-    "nodemailer": "^0.7.1"
+    "nodemailer": "^4.1.0"
   },
   "devDependencies": {
-    "express": "^3.20.2",
+    "express": "^4.15.3",
     "jade": "^0.27.7",
-    "mocha": "^1.5.0",
-    "superagent": "^0.9.10",
-    "should": "^1.2.2",
-    "sinon": "^1.4.2",
+    "mocha": "^3.5.0",
     "rewire": "^1.0.4",
     "test-mailbox": "^0.0.6"
+    "should": "^1.2.2",
+    "sinon": "^3.2.1",
+    "superagent": "^0.9.10",
   },
   "scripts" : {
     "test" : "make test",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "jade": "^0.27.7",
     "mocha": "^3.5.0",
     "rewire": "^1.0.4",
-    "test-mailbox": "^0.0.6"
+    "test-mailbox": "^0.0.6",
     "should": "^1.2.2",
     "sinon": "^3.2.1",
-    "superagent": "^0.9.10",
+    "superagent": "^0.9.10"
   },
   "scripts" : {
     "test" : "make test",

--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,9 @@ var app = require('express')(),
 mailer.extend(app, {
   from: 'no-reply@example.com',
   host: 'smtp.gmail.com', // hostname
-  secureConnection: true, // use SSL
-  port: 465, // port for secure SMTP
-  transportMethod: 'SMTP', // default is SMTP. Accepts anything that nodemailer accepts
+  port: 465, // port for secure SMTP, true for 465, false for other ports
+  secure: true, // use SSL
+  transportMethod: 'SMTP', // optional : default is SMTP. Accepts anything that nodemailer accepts
   auth: {
     user: 'gmail.user@gmail.com',
     pass: 'userpass'
@@ -60,7 +60,7 @@ Then we can write our templates in Jade:
 ```javascript
 // project/views/email.jade
 
-!!! transitional
+doctype transitional
 html
   head
     meta(http-equiv = 'Content-Type', content = 'text/html; charset=UTF-8')


### PR DESCRIPTION
Fixes the warning "All versions below 4.0.1 of Nodemailer are deprecated"
Changed ReadMe's Jade marking as per @zachMoreno's pull request